### PR TITLE
✅ Improve Go Workflow: Use go-version-file and Reorder Steps

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version-file: 'go.mod'
       - uses: actions/checkout@v4
       - name: Run tests
         run: go test -race ./...
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version-file: 'go.mod'
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.7.1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,10 +14,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - uses: actions/checkout@v4
       - name: Run tests
         run: go test -race ./...
   lint:
@@ -30,10 +30,10 @@ jobs:
         os: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.7.1
         with:


### PR DESCRIPTION


#### What changed
This PR updates the `.github/workflows/go.yml` file to improve maintainability and follow best practices in the GitHub Actions workflow for Go projects.

#### Summary of Changes
- **Switched to `go-version-file`:**  
  Replaced the hardcoded Go version (`1.20`) with `go-version-file: 'go.mod'` in both the `test` and `lint` jobs. This ensures the CI uses the same Go version defined in `go.mod`.

- **Reordered workflow steps:**  
  Moved the `actions/checkout@v4` step above `actions/setup-go@v5`. This ensures the repository is checked out before trying to load the `go.mod` file, avoiding potential setup issues.

#### Why
- **Maintainability:** Updating the Go version now requires only a single change in `go.mod`, instead of editing the workflow file.
- **Correctness & Best Practices:** Ensuring the repo is checked out before setting up Go prevents issues where `setup-go` can't find the `go.mod` file, and aligns with recommended practices.

#### Impact
More reliable and easier-to-maintain CI pipeline for Go projects, with better alignment between local development and CI environments.
