### PR TITLE
Use go 1.21

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,4 +37,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6.5.2
         with:
-          version: v1.52.0
+          version: v1.54.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ linters:
   enable:
     - bodyclose
     - contextcheck
-    - depguard
+    # - depguard
     - durationcheck
     - dupl
     - errchkjson

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/99designs/aws-vault/v7
 
-go 1.20
+go 1.21
 
 require (
 	github.com/99designs/keyring v1.2.2


### PR DESCRIPTION
Depguard issues

> Run golangci/golangci-lint-action@v3.4.0
> prepare environment
> run golangci-lint
>   Running [/Users/runner/golangci-lint-1.54.2-darwin-arm64/golangci-lint run --out-format=github-actions] in [] ...
>   Error: import 'github.com/mattn/go-tty' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/99designs/aws-vault/v7/iso8601' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/aws' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/99designs/aws-vault/v7/iso8601' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/99designs/aws-vault/v7/vault' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/aws' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/service/sts' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/99designs/aws-vault/v7/cli' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/alecthomas/kingpin/v2' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/99designs/aws-vault/v7/prompt' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/99designs/aws-vault/v7/vault' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/99designs/keyring' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/alecthomas/kingpin/v2' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/aws' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/99designs/aws-vault/v7/vault' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/99designs/keyring' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/alecthomas/kingpin/v2' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/99designs/aws-vault/v7/iso8601' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/99designs/aws-vault/v7/server' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/99designs/keyring' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/99designs/aws-vault/v7/prompt' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/mattn/go-isatty' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/config' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/credentials' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/service/sts' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/skratchdot/open-golang/open' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/99designs/aws-vault/v7/server' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/99designs/aws-vault/v7/prompt' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/service/iam' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/service/sts' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/service/sts/types' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/service/sts/types' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/service/sts/types' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/service/iam' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/service/ssooidc' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/aws/transport/http' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/service/sso' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/service/sso/types' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/service/ssooidc' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/service/ssooidc/types' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/skratchdot/open-golang/open' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/service/sso' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/aws/aws-sdk-go-v2/service/ssooidc' is not allowed from list 'Main' (depguard)
>   Error: import 'github.com/google/go-cmp/cmp' is not allowed from list 'Main' (depguard)
>   
>   Error: issues found
>   Ran golangci-lint in 16843ms