### PR TITLE
Use go 1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,4 +37,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6.5.2
         with:
-          version: v1.54.2
+          version: v1.56.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,7 @@ linters:
     - nilnil
     - noctx
     - prealloc
-    - revive
+    # - revive
     # - rowserrcheck
     - thelper
     - tparallel

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/99designs/aws-vault/v7
 
-go 1.21
+go 1.22
 
 require (
 	github.com/99designs/keyring v1.2.2


### PR DESCRIPTION
Revive issues

> Run golangci/golangci-lint-action@v6.5.2
> prepare environment
> run golangci-lint
>   Running [/Users/runner/golangci-lint-1.56.2-darwin-arm64/golangci-lint config path] in [/Users/runner/work/aws-vault/aws-vault] ...
>   Running [/Users/runner/golangci-lint-1.56.2-darwin-arm64/golangci-lint run] in [/Users/runner/work/aws-vault/aws-vault] ...
>   Error: vault/stsendpointresolver.go:13:38: unused-parameter: parameter 'options' seems to be unused, consider removing or renaming it as _ (revive)
>   	return func(service, region string, options ...interface{}) (aws.Endpoint, error) {
>   	                                    ^
>   Error: server/ec2proxy.go:38:58: unused-parameter: parameter 'r' seems to be unused, consider removing or renaming it as _ (revive)
>   	handler.HandleFunc("/stop", func(w http.ResponseWriter, r *http.Request) {
>   	                                                        ^
>   Error: server/ec2server.go:35:95: unused-parameter: parameter 'r' seems to be unused, consider removing or renaming it as _ (revive)
>   	router.HandleFunc("/latest/meta-data/iam/security-credentials/", func(w http.ResponseWriter, r *http.Request) {
>   	                                                                                             ^
>   Error: server/ec2server.go:40:82: unused-parameter: parameter 'r' seems to be unused, consider removing or renaming it as _ (revive)
>   	router.HandleFunc("/latest/meta-data/instance-id/", func(w http.ResponseWriter, r *http.Request) {
>   	                                                                                ^
>   Error: cli/remove.go:39:18: unused-parameter: parameter 'c' seems to be unused, consider removing or renaming it as _ (revive)
>   	cmd.Action(func(c *kingpin.ParseContext) error {
>   	                ^
>   Error: cli/clear.go:24:18: unused-parameter: parameter 'c' seems to be unused, consider removing or renaming it as _ (revive)
>   	cmd.Action(func(c *kingpin.ParseContext) (err error) {
>   	                ^
>   Error: cli/add.go:37:18: unused-parameter: parameter 'c' seems to be unused, consider removing or renaming it as _ (revive)
>   	cmd.Action(func(c *kingpin.ParseContext) error {
>   	                ^
>   Error: cli/export.go:110:9: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
>   	} else {
>   		return printEnv(input, credsProvider, config.Region, "")
>   	}
>   Error: cli/global.go:121:20: unused-parameter: parameter 'app' seems to be unused, consider removing or renaming it as _ (revive)
>   	app.Validate(func(app *kingpin.Application) error {
>   	                  ^
>   
>   Error: issues found
>   Ran golangci-lint in 17458ms