### PR TITLE
Use go 1.23

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,4 +37,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6.5.2
         with:
-          version: v1.56.2
+          version: v1.60.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/99designs/aws-vault/v7
 
-go 1.22
+go 1.23
 
 require (
 	github.com/99designs/keyring v1.2.2

--- a/server/ec2server.go
+++ b/server/ec2server.go
@@ -48,7 +48,7 @@ func startEc2CredentialsServer(credsProvider aws.CredentialsProvider, region str
 
 	// used by AWS SDK to determine region
 	router.HandleFunc("/latest/dynamic/instance-identity/document", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, `{"region": "`+region+`"}`)
+		fmt.Fprintf(w, `{"region": "%s"}`, region)
 	})
 
 	router.HandleFunc("/latest/meta-data/iam/security-credentials/local-credentials", credsHandler(credsProvider))


### PR DESCRIPTION
Fix
```
Run golangci/golangci-lint-action@v6.5.2
prepare environment
run golangci-lint
  Running [/Users/runner/golangci-lint-1.60.3-darwin-arm64/golangci-lint config path] in [/Users/runner/work/aws-vault/aws-vault] ...
  Running [/Users/runner/golangci-lint-1.60.3-darwin-arm64/golangci-lint config verify] in [/Users/runner/work/aws-vault/aws-vault] ...
  Running [/Users/runner/golangci-lint-1.60.3-darwin-arm64/golangci-lint run] in [/Users/runner/work/aws-vault/aws-vault] ...
  Error: server/ec2server.go:51:18: printf: non-constant format string in call to fmt.Fprintf (govet)
  		fmt.Fprintf(w, `{"region": "`+region+`"}`)
  		               ^
  
  level=warning msg="The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar."
  
  Error: issues found
  Ran golangci-lint in 17592ms
```