### PR TITLE
.golangci.yml: Replace exportloopref with copyloopvar

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters:
     - errchkjson
     - errname
     - exhaustive
-    - exportloopref
+    - copyloopvar
     - gofmt
     - goimports
     - makezero


### PR DESCRIPTION
```
run golangci-lint
  Running [/home/runner/golangci-lint-1.60.3-linux-amd64/golangci-lint config path] in [/home/runner/work/aws-vault/aws-vault] ...
  Running [/home/runner/golangci-lint-1.60.3-linux-amd64/golangci-lint config verify] in [/home/runner/work/aws-vault/aws-vault] ...
  Running [/home/runner/golangci-lint-1.60.3-linux-amd64/golangci-lint run] in [/home/runner/work/aws-vault/aws-vault] ...
  level=warning msg="The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar."
  
  golangci-lint found no issues
  Ran golangci-lint in 25267ms
```