### PR TITLE
fix: prepare v8.0.1 release with module versioning and dependency updates

### DIFF
--- a/cli/add.go
+++ b/cli/add.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/vincentclee/aws-vault/v7/prompt"
-	"github.com/vincentclee/aws-vault/v7/vault"
+	"github.com/vincentclee/aws-vault/v8/prompt"
+	"github.com/vincentclee/aws-vault/v8/vault"
 	"github.com/vincentclee/keyring/v2"
 )
 

--- a/cli/clear.go
+++ b/cli/clear.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/vincentclee/aws-vault/v7/vault"
+	"github.com/vincentclee/aws-vault/v8/vault"
 	"github.com/vincentclee/keyring/v2"
 )
 

--- a/cli/exec.go
+++ b/cli/exec.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/vincentclee/aws-vault/v7/iso8601"
-	"github.com/vincentclee/aws-vault/v7/server"
-	"github.com/vincentclee/aws-vault/v7/vault"
+	"github.com/vincentclee/aws-vault/v8/iso8601"
+	"github.com/vincentclee/aws-vault/v8/server"
+	"github.com/vincentclee/aws-vault/v8/vault"
 	"github.com/vincentclee/keyring/v2"
 )
 

--- a/cli/export.go
+++ b/cli/export.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/vincentclee/aws-vault/v7/iso8601"
-	"github.com/vincentclee/aws-vault/v7/vault"
+	"github.com/vincentclee/aws-vault/v8/iso8601"
+	"github.com/vincentclee/aws-vault/v8/vault"
 	"github.com/vincentclee/keyring/v2"
 	ini "gopkg.in/ini.v1"
 )

--- a/cli/global.go
+++ b/cli/global.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/alecthomas/kingpin/v2"
 	isatty "github.com/mattn/go-isatty"
-	"github.com/vincentclee/aws-vault/v7/prompt"
-	"github.com/vincentclee/aws-vault/v7/vault"
+	"github.com/vincentclee/aws-vault/v8/prompt"
+	"github.com/vincentclee/aws-vault/v8/vault"
 	"github.com/vincentclee/keyring/v2"
 	"golang.org/x/term"
 )

--- a/cli/list.go
+++ b/cli/list.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/vincentclee/aws-vault/v7/vault"
+	"github.com/vincentclee/aws-vault/v8/vault"
 	"github.com/vincentclee/keyring/v2"
 )
 

--- a/cli/login.go
+++ b/cli/login.go
@@ -16,7 +16,7 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/skratchdot/open-golang/open"
-	"github.com/vincentclee/aws-vault/v7/vault"
+	"github.com/vincentclee/aws-vault/v8/vault"
 	"github.com/vincentclee/keyring/v2"
 )
 

--- a/cli/proxy.go
+++ b/cli/proxy.go
@@ -6,7 +6,7 @@ import (
 	"syscall"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/vincentclee/aws-vault/v7/server"
+	"github.com/vincentclee/aws-vault/v8/server"
 )
 
 func ConfigureProxyCommand(app *kingpin.Application) {

--- a/cli/remove.go
+++ b/cli/remove.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/vincentclee/aws-vault/v7/prompt"
-	"github.com/vincentclee/aws-vault/v7/vault"
+	"github.com/vincentclee/aws-vault/v8/prompt"
+	"github.com/vincentclee/aws-vault/v8/vault"
 	"github.com/vincentclee/keyring/v2"
 )
 

--- a/cli/rotate.go
+++ b/cli/rotate.go
@@ -9,7 +9,7 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
-	"github.com/vincentclee/aws-vault/v7/vault"
+	"github.com/vincentclee/aws-vault/v8/vault"
 	"github.com/vincentclee/keyring/v2"
 )
 

--- a/contrib/_aws-vault-proxy/go.mod
+++ b/contrib/_aws-vault-proxy/go.mod
@@ -1,7 +1,7 @@
 module aws-vault-ecs-server-reverse-proxy
 
-go 1.17
+go 1.24
 
 require github.com/gorilla/handlers v1.5.2
 
-require github.com/felixge/httpsnoop v1.0.3 // indirect
+require github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/contrib/_aws-vault-proxy/go.sum
+++ b/contrib/_aws-vault-proxy/go.sum
@@ -1,8 +1,4 @@
-github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
-github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
-github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
-github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
+github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
+github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/gorilla/handlers v1.5.2 h1:cLTUSsNkgcwhgRqvCNmdbRWG0A3N4F+M2nWKdScwyEE=
 github.com/gorilla/handlers v1.5.2/go.mod h1:dX+xVpaxdSw+q0Qek8SSsl3dfMk3jNddUkMzo0GtH0w=

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 RUN apt update && apt install -y curl
-RUN curl -fLs -o /usr/local/bin/aws-vault https://github.com/vincentclee/aws-vault/releases/download/v6.3.1/aws-vault-linux-amd64 && chmod 755 /usr/local/bin/aws-vault
+RUN curl -fLs -o /usr/local/bin/aws-vault https://github.com/vincentclee/aws-vault/releases/download/v8.0.0/aws-vault-linux-amd64 && chmod 755 /usr/local/bin/aws-vault
 ENV AWS_VAULT_BACKEND=file
 ENTRYPOINT ["/usr/local/bin/aws-vault"]
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vincentclee/aws-vault/v7
+module github.com/vincentclee/aws-vault/v8
 
 go 1.24
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/vincentclee/aws-vault/v7/cli"
+	"github.com/vincentclee/aws-vault/v8/cli"
 )
 
 // Version is provided at compile time

--- a/server/ec2server.go
+++ b/server/ec2server.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/vincentclee/aws-vault/v7/iso8601"
+	"github.com/vincentclee/aws-vault/v8/iso8601"
 )
 
 const ec2CredentialsServerAddr = "127.0.0.1:9099"

--- a/server/ecsserver.go
+++ b/server/ecsserver.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/vincentclee/aws-vault/v7/iso8601"
-	"github.com/vincentclee/aws-vault/v7/vault"
+	"github.com/vincentclee/aws-vault/v8/iso8601"
+	"github.com/vincentclee/aws-vault/v8/vault"
 )
 
 func writeErrorMessage(w http.ResponseWriter, msg string, statusCode int) {

--- a/vault/config_test.go
+++ b/vault/config_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/vincentclee/aws-vault/v7/vault"
+	"github.com/vincentclee/aws-vault/v8/vault"
 )
 
 // see http://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html

--- a/vault/mfa.go
+++ b/vault/mfa.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/vincentclee/aws-vault/v7/prompt"
+	"github.com/vincentclee/aws-vault/v8/prompt"
 )
 
 // Mfa contains options for an MFA device

--- a/vault/sessionkeyring_test.go
+++ b/vault/sessionkeyring_test.go
@@ -3,7 +3,7 @@ package vault_test
 import (
 	"testing"
 
-	"github.com/vincentclee/aws-vault/v7/vault"
+	"github.com/vincentclee/aws-vault/v8/vault"
 )
 
 func TestIsSessionKey(t *testing.T) {

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/vincentclee/aws-vault/v7/vault"
+	"github.com/vincentclee/aws-vault/v8/vault"
 	"github.com/vincentclee/keyring/v2"
 )
 


### PR DESCRIPTION


- Update go.mod module path from v7 to v8 across all projects
- Update all internal import paths to use /v8 suffix for Go module compliance
- Update contrib/_aws-vault-proxy to Go 1.24 and latest dependencies
- Clean up proxy project dependencies (httpsnoop v1.0.3 → v1.0.4)
- Update Docker configurations for v8 module paths
- Remove stale dependency entries from go.sum files

This addresses the module versioning issues from the v8.0.0 release and ensures all sub-projects are updated and consistent.

Fixes: #v8.0.0-module-versioning