### PR TITLE
Upgrade to Go 1.26

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,4 +37,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.4.0
+          version: v2.11.4

--- a/cli/global.go
+++ b/cli/global.go
@@ -99,7 +99,7 @@ func ConfigureGlobals(app *kingpin.Application) *AwsVault {
 		KeyringConfig: keyringConfigDefaults,
 	}
 
-	backendsAvailable := []string{}
+	backendsAvailable := make([]string, 0, len(keyring.AvailableBackends()))
 	for _, backendType := range keyring.AvailableBackends() {
 		backendsAvailable = append(backendsAvailable, string(backendType))
 	}

--- a/contrib/_aws-vault-proxy/Dockerfile
+++ b/contrib/_aws-vault-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25
+FROM golang:1.26
 WORKDIR /usr/src/aws-vault-proxy
 COPY . /usr/src/aws-vault-proxy
 RUN go build -v -o /usr/local/bin/aws-vault-proxy ./...

--- a/contrib/_aws-vault-proxy/go.mod
+++ b/contrib/_aws-vault-proxy/go.mod
@@ -1,6 +1,6 @@
 module aws-vault-ecs-server-reverse-proxy
 
-go 1.25
+go 1.26
 
 require github.com/gorilla/handlers v1.5.2
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vincentclee/aws-vault/v8
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0

--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -10,7 +10,7 @@ type Func func(string) (string, error)
 var Methods = map[string]Func{}
 
 func Available() []string {
-	methods := []string{}
+	methods := make([]string, 0, len(Methods))
 	for k := range Methods {
 		methods = append(methods, k)
 	}

--- a/vault/config.go
+++ b/vault/config.go
@@ -260,7 +260,7 @@ func (c *ConfigFile) Add(profile ProfileSection) error {
 
 // ProfileNames returns a slice of profile names from the AWS config
 func (c *ConfigFile) ProfileNames() []string {
-	profileNames := []string{}
+	profileNames := make([]string, 0, len(c.ProfileSections()))
 	for _, profile := range c.ProfileSections() {
 		profileNames = append(profileNames, profile.Name)
 	}


### PR DESCRIPTION
# Upgrade to Go 1.26

## Summary

Upgrades the project from Go 1.25 to Go 1.26 and bumps `golangci-lint` from v2.4.0 to v2.11.4, fixing new lint issues introduced by the linter upgrade.

## Changes

### Go 1.26 Upgrade
- `go.mod` — bumped `go 1.25.0` → `go 1.26.0`
- `contrib/_aws-vault-proxy/go.mod` — bumped `go 1.25` → `go 1.26`
- `contrib/_aws-vault-proxy/Dockerfile` — updated base image `golang:1.25` → `golang:1.26`

### golangci-lint Upgrade
- `.github/workflows/go.yml` — bumped `golangci-lint` from `v2.4.0` → `v2.11.4`

### Lint Fixes (`prealloc`)
The `prealloc` linter in the new `golangci-lint` version flags slices that can be preallocated with a known capacity. Fixed 3 occurrences:

- `cli/global.go` — `backendsAvailable` slice preallocated with `len(keyring.AvailableBackends())`
- `prompt/prompt.go` — `methods` slice preallocated with `len(Methods)`
- `vault/config.go` — `profileNames` slice preallocated with `len(c.ProfileSections())`

## Testing

- `go build ./...` ✅
- `go test ./...` ✅
- `golangci-lint run ./...` — 0 issues ✅
