### PR TITLE
chore: configure weekly automerge for AWS SDK updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "schedule:weekly"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePrefixes": ["github.com/aws/aws-sdk-go-v2"],
+      "groupName": "aws-sdk-go-v2 monorepo",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "branch"
+    }
   ]
 }


### PR DESCRIPTION
Configures Renovate to:
- Run on a **weekly schedule** (Mondays before 4 AM) for branch creation and updates
- **Automerge** AWS SDK v2 minor/patch updates silently via branch merge (no PR noise) — automerge happens whenever CI passes, independent of the schedule
- Major version updates still create a PR for manual review